### PR TITLE
add firebaserc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Firebase
+.firebaserc


### PR DESCRIPTION
firebaserc is added to gitignore so it doesn't conflict with new `firebase init` commands