### PR TITLE
[functions] Add typeRoots path on functions/tsconfig.json

### DIFF
--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -5,7 +5,8 @@
     "noImplicitReturns": true,
     "outDir": "lib",
     "sourceMap": true,
-    "target": "es6"
+    "target": "es6",
+    "typeRoots": ["./node_modules/@types"]
   },
   "compileOnSave": true,
   "include": [


### PR DESCRIPTION
### Avoid Typescript from looking in parent types project during functions build https://github.com/codediodeio/angular-firestarter/issues/63

typeRoots path added on on functions/tsconfig.json

This pull request will fix this issue: https://github.com/codediodeio/angular-firestarter/issues/63