### PR TITLE
Excludes /functions dir from prerender builds

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,4 +17,7 @@
       "dom"
     ]
   }
+  "exclude": [
+    "functions"
+  ]
 }


### PR DESCRIPTION
The npm run build:all will fail if the /functions directory exist when deploying. This will exclude that directory for building and deploying the site only.